### PR TITLE
Support for Multiple Filter(startAt, endAt, limitToFirst, limitToEnd)

### DIFF
--- a/src/rtdb/utils.ts
+++ b/src/rtdb/utils.ts
@@ -40,13 +40,17 @@ export const createQuery = ({
   // filter
   if (!isUndefined(directives.limitToFirst)) {
     query = query.limitToFirst(directives.limitToFirst);
-  } else if (!isUndefined(directives.limitToLast)) {
+  }
+  if (!isUndefined(directives.limitToLast)) {
     query = query.limitToLast(directives.limitToLast);
-  } else if (!isUndefined(directives.startAt)) {
+  }
+  if (!isUndefined(directives.startAt)) {
     query = query.startAt(directives.startAt);
-  } else if (!isUndefined(directives.endAt)) {
+  }
+  if (!isUndefined(directives.endAt)) {
     query = query.endAt(directives.endAt);
-  } else if (!isUndefined(directives.equalTo)) {
+  }
+  if (!isUndefined(directives.equalTo)) {
     query = query.equalTo(directives.equalTo);
   }
   return query;

--- a/test/rtdbLink.spec.ts
+++ b/test/rtdbLink.spec.ts
@@ -267,6 +267,29 @@ describe('rtdbLink', () => {
       expect(data.articles.length).to.be.equal(2);
     });
 
+    it('should query array with startAt & limitToFirst', async () => {
+      const query = gql`
+        query($ref: string) {
+          articles @rtdbQuery(ref: $ref, orderByChild: "count", startAt: 2, limitToFirst: 2) @array {
+            id @key
+            count,
+            title
+          }
+        }
+      `;
+
+      const {data} = await makePromise<Result>(
+        execute(link, {
+          operationName: 'query',
+          query,
+          variables: {ref: `${TEST_NAMESPACE}/articles`}
+        }),
+      );
+      expect(data.articles[0].count < data.articles[1].count).to.be.true;
+      expect(data.articles.length).to.be.equal(2);
+      expect(data.articles[0].count).to.be.equal(2);
+    });
+
     it('should query nested array', async () => {
       const query = gql`
         query($ref: string) {


### PR DESCRIPTION
Hello,

I'm creating an application using this awesome library and I realized that it doesn't support using filter "startAt" with "limitToFirst" together in a query.

According to the firebase document, "startAt" and "limitToFirst" should be able to be used together.
https://firebase.google.com/docs/database/admin/retrieve-data?hl=en&authuser=1#header_4

So, I fixed a little of the codes to support that case.

Please check it and merge.

Thanks in advance😀